### PR TITLE
Bank Adapter spec proto changes

### DIFF
--- a/upi-india/issuer-switch/bank-adapter/spec/v1/account_types.proto
+++ b/upi-india/issuer-switch/bank-adapter/spec/v1/account_types.proto
@@ -1,20 +1,20 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//      https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 syntax = "proto3";
 
-package google.cloud.paymentgateway.issuerswitch.bankadapter.v1;
+package google.cloud.paymentgateway.issuerswitch.adapter.bank.v1;
 
 import "cloud/api_products/payment_gateway/upi_india/bank_adapter/spec/issuer/v1/common_types.proto";
 import "google/api/field_behavior.proto";
@@ -22,7 +22,7 @@ import "google/protobuf/timestamp.proto";
 
 option java_outer_classname = "AccountTypesProto";
 option java_multiple_files = true;
-option java_package = "com.google.cloud.paymentgateway.issuerswitch.bankadapter.v1";
+option java_package = "com.google.cloud.paymentgateway.issuerswitch.adapter.bank.v1";
 option go_api_flag = "OPAQUE_V0";
 
 // Provides information about an account.
@@ -73,51 +73,83 @@ message ValidityPeriod {
 
 // Request to hold funds in an account.
 message HoldFundsRequest {
-  // An identifier for this request. This is used to correlate a hold
-  // funds request to a release funds request. In UPI, this field maps to the
-  // Unified Mandate Number (UMN).
-  string request_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // Payer in the transaction.
-  SettlementParticipant payer = 2 [(google.api.field_behavior) = REQUIRED];
-  // Payee in the transaction.
-  SettlementParticipant payee = 3 [(google.api.field_behavior) = REQUIRED];
-  // Specifies the amount to be held and the holding type rule.
-  HoldAmount hold_amount = 4 [(google.api.field_behavior) = REQUIRED];
-  // Identifier for the mandate creation transaction.
-  string transaction_id = 5 [(google.api.field_behavior) = REQUIRED];
-  // Specifies the validity period for the funds to be held.
-  ValidityPeriod validity_period = 6 [(google.api.field_behavior) = REQUIRED];
-  // Free form string describing the hold request.
-  string description = 7;
-  // Additional payment information specific to India's UPI requirements.
-  PaymentAdditionalInfo payment_additional_info = 8;
-  // If the hold funds call is triggered to update an existing hold on funds,
-  // then this field will contain the original hold funds reference and the
-  // amount held originally. In other cases, this field will be omitted in the
-  // request.
-  HoldDetails original_hold_details = 9;
-  // Reason for this hold request.
-  HoldReason hold_reason = 10 [(google.api.field_behavior) = REQUIRED];
-  // Metadata about the API invocation received by the issuer switch which
-  // triggered this request to the bank adapter.
-  InvocationMetadata invocation_metadata = 11
-      [(google.api.field_behavior) = REQUIRED];
-  // Indicates whether the hold funds request is for a mandate or a voucher.
-  enum HoldReason {
-    // Unspecified hold reason.
-    REASON_UNSPECIFIED = 0;
-    // Hold funds for mandate.
-    MANDATE = 1;
-    // Hold funds for voucher.
-    VOUCHER = 2;
+  // Payload for hold funds request.
+  message Payload {
+    // An identifier for this request. This is used to correlate a hold
+    // funds request to a release funds request. In UPI, this field maps to the
+    // Unified Mandate Number (UMN).
+    string request_id = 1 [(google.api.field_behavior) = REQUIRED];
+    // Payer in the transaction.
+    SettlementParticipant payer = 2 [(google.api.field_behavior) = REQUIRED];
+    // Payee in the transaction.
+    SettlementParticipant payee = 3 [(google.api.field_behavior) = REQUIRED];
+    // Specifies the amount to be held and the holding type rule.
+    HoldAmount hold_amount = 4 [(google.api.field_behavior) = REQUIRED];
+    // Identifier for the mandate creation transaction.
+    string transaction_id = 5 [(google.api.field_behavior) = REQUIRED];
+    // Specifies the validity period for the funds to be held.
+    ValidityPeriod validity_period = 6 [(google.api.field_behavior) = REQUIRED];
+    // Free form string describing the hold request.
+    string description = 7;
+    // Additional payment information specific to India's UPI requirements.
+    PaymentAdditionalInfo payment_additional_info = 8;
+    // If the hold funds call is triggered to update an existing hold on funds,
+    // then this field will contain the original hold funds reference and the
+    // amount held originally. In other cases, this field will be omitted in the
+    // request.
+    HoldDetails original_hold_details = 9;
+    // Reason for this hold request.
+    HoldReason hold_reason = 10 [(google.api.field_behavior) = REQUIRED];
+    // Metadata about the API invocation received by the issuer switch which
+    // triggered this request to the bank adapter.
+    InvocationMetadata invocation_metadata = 11
+        [(google.api.field_behavior) = REQUIRED];
+    // Indicates whether the hold funds request is for a mandate or a voucher.
+    enum HoldReason {
+      // Unspecified hold reason.
+      REASON_UNSPECIFIED = 0;
+      // Hold funds for mandate.
+      MANDATE = 1;
+      // Hold funds for voucher.
+      VOUCHER = 2;
+    }
+  }
+
+  // The request sent can be either a plain text request or encrypted in a
+  // Base64 encoded JSON string
+  oneof request {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.HoldFundsRequest.Payload]
+    // message.
+    string encrypted = 2;
   }
 }
 
 // Response for the HoldFunds method.
 message HoldFundsResponse {
-  // The bank's reference for the funds held in an account. This value is
-  // alpha-numeric and should be exactly 6 characters long.
-  string hold_reference = 1 [(google.api.field_behavior) = REQUIRED];
+  // Payload for hold funds response.
+  message Payload {
+    // The bank's reference for the funds held in an account. This value is
+    // alpha-numeric and should be exactly 6 characters long.
+    string hold_reference = 1 [(google.api.field_behavior) = REQUIRED];
+    // Any additional metadata about the response from the bank adapter.
+    ResponseMetadata response_metadata = 2;
+  }
+
+  // The response sent can be either a plain text response or encrypted in a
+  // Base64 encoded JSON string
+  oneof response {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.HoldFundsResponse.Payload]
+    // message.
+    string encrypted = 2;
+  }
 }
 
 // Details of the funds to be released.
@@ -128,94 +160,198 @@ message ReleaseDetails {
 
 // Request to release previously held funds in an account.
 message ReleaseFundsRequest {
-  // An identifier for this request which must be the same as the identifier for
-  // a previous hold funds request. This is used to correlate a hold
-  // funds request to a release funds request. In UPI, this field maps to the
-  // Unified Mandate Number (UMN).
-  string request_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // Payer in the transaction.
-  SettlementParticipant payer = 2 [(google.api.field_behavior) = REQUIRED];
-  // Payee in the transaction.
-  SettlementParticipant payee = 3 [(google.api.field_behavior) = REQUIRED];
-  // Identifier of the original hold funds transaction.
-  string original_transaction_id = 4 [(google.api.field_behavior) = REQUIRED];
-  // The bank's reference for the funds held in the account which are being
-  // released. It specifies the amount held and the hold reference returned when
-  // the funds were initially held in the account.
-  HoldDetails hold_details = 5 [(google.api.field_behavior) = REQUIRED];
-  // Details of the funds to be released. *Note* that the amount to be released
-  // will be less than or equal to the amount that was originally held.
-  ReleaseDetails release_details = 6 [(google.api.field_behavior) = REQUIRED];
-  // Additional information for executing the request.
-  PaymentAdditionalInfo additional_info = 7;
-  // Metadata about the API invocation received by the issuer switch which
-  // triggered this request to the bank adapter.
-  InvocationMetadata invocation_metadata = 8
-      [(google.api.field_behavior) = REQUIRED];
+  // Payload for release funds request.
+  message Payload {
+    // An identifier for this request which must be the same as the identifier
+    // for a previous hold funds request. This is used to correlate a hold funds
+    // request to a release funds request. In UPI, this field maps to the
+    // Unified Mandate Number (UMN).
+    string request_id = 1 [(google.api.field_behavior) = REQUIRED];
+    // Payer in the transaction.
+    SettlementParticipant payer = 2 [(google.api.field_behavior) = REQUIRED];
+    // Payee in the transaction.
+    SettlementParticipant payee = 3 [(google.api.field_behavior) = REQUIRED];
+    // Identifier of the original hold funds transaction.
+    string original_transaction_id = 4 [(google.api.field_behavior) = REQUIRED];
+    // The bank's reference for the funds held in the account which are being
+    // released. It specifies the amount held and the hold reference returned
+    // when the funds were initially held in the account.
+    HoldDetails hold_details = 5 [(google.api.field_behavior) = REQUIRED];
+    // Details of the funds to be released. *Note* that the amount to be
+    // released will be less than or equal to the amount that was originally
+    // held.
+    ReleaseDetails release_details = 6 [(google.api.field_behavior) = REQUIRED];
+    // Additional information for executing the request.
+    PaymentAdditionalInfo additional_info = 7;
+    // Metadata about the API invocation received by the issuer switch which
+    // triggered this request to the bank adapter. *Note* that in case of
+    // release
+    // of funds for expired or partially executed mandates, invocation metadata
+    // will not be included in the request as this API will be invoked directly
+    // by the issuer switch and not as part of any UPI API flows.
+    InvocationMetadata invocation_metadata = 8
+        [(google.api.field_behavior) = REQUIRED];
+  }
+
+  // The request sent can be either a plain text request or encrypted in a
+  // Base64 encoded JSON string
+  oneof request {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.ReleaseFundsRequest.Payload]
+    // message.
+    string encrypted = 2;
+  }
+}
+
+// Response to release request of previously held funds in an account.
+message ReleaseFundsResponse {
+  // Payload for the release funds response.
+  message Payload {
+    // Any additional metadata about the response from the bank adapter.
+    ResponseMetadata response_metadata = 1;
+  }
+  // The response sent can be either a plain text response or encrypted in a
+  // Base64 encoded JSON string
+  oneof response {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.ReleaseFundsResponse.Payload]
+    // message.
+    string encrypted = 2;
+  }
 }
 
 // Request to search for accounts, given a customer reference or an account
 // reference.
 message SearchAccountsRequest {
-  // Either a customer reference or a bank account reference will be
-  // provided. Only one of the two will be specified.
-  oneof reference {
-    // Reference of customer used to search for accounts.
-    CustomerReference customer_reference = 1;
-    // A reference to uniquely identify a customer's bank account based on
-    // India's UPI standards.
-    AccountReference account_reference = 2;
+  // Payload for search accounts request.
+  message Payload {
+    // Either a customer reference or a bank account reference will be
+    // provided. Only one of the two will be specified.
+    oneof reference {
+      // Reference of customer used to search for accounts.
+      CustomerReference customer_reference = 1;
+      // A reference to uniquely identify a customer's bank account based on
+      // India's UPI standards.
+      AccountReference account_reference = 2;
+    }
+    // Additional information that should be returned about the accounts that
+    // match the request. If no additional information of the relevant type is
+    // associated with an account that matches the request, then that type can
+    // be omitted for that account in this API's response.
+    //
+    // For example, if this field contains the enum RESIDENT_ID, then, in the
+    // [additional_info][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.AccountInfo.additional_info]
+    // field for each account, the bank adapter should return the Aadhaar number
+    // associated with that account, if any.
+    repeated AccountInfo.AdditionalInfo.Type additional_info_types = 3;
+    // Metadata about the API invocation received by the issuer switch which
+    // triggered this request to the bank adapter.
+    InvocationMetadata invocation_metadata = 4
+        [(google.api.field_behavior) = REQUIRED];
   }
-  // Additional information that should be returned about the accounts that
-  // match the request. If no additional information of the relevant type is
-  // associated with an account that matches the request, then that type can be
-  // omitted for that account in this API's response.
-  //
-  // For example, if this field contains the enum RESIDENT_ID, then, in the
-  // [additional_info][google.cloud.paymentgateway.issuerswitch.bankadapter.v1.AccountInfo.additional_info]
-  // field for each account, the bank adapter should return the Aadhaar number
-  // associated with that account, if any.
-  repeated AccountInfo.AdditionalInfo.Type additional_info_types = 3;
-  // Metadata about the API invocation received by the issuer switch which
-  // triggered this request to the bank adapter.
-  InvocationMetadata invocation_metadata = 4
-      [(google.api.field_behavior) = REQUIRED];
+
+  // The request sent can be either a plain text request or encrypted in a
+  // Base64 encoded JSON string
+  oneof request {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.SearchAccountsRequest.Payload]
+    // message.
+    string encrypted = 2;
+  }
 }
 
 // Response for the SearchAccount method.
 message SearchAccountsResponse {
-  // List of accounts matching the search criteria.
-  repeated AccountInfo accounts = 1 [(google.api.field_behavior) = REQUIRED];
+  // Payload for search accounts response.
+  message Payload {
+    // List of accounts matching the search criteria.
+    repeated AccountInfo accounts = 1 [(google.api.field_behavior) = REQUIRED];
+    // Any additional metadata about the response from the bank adapter.
+    ResponseMetadata response_metadata = 2;
+  }
+
+  // The response sent can be either a plain text response or encrypted in a
+  // Base64 encoded JSON string
+  oneof response {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.SearchAccountsResponse.Payload]
+    // message.
+    string encrypted = 2;
+  }
 }
 
 // Request to retrieve an account balance.
 message RetrieveBalanceRequest {
-  // Identifies the customer or bank account whose account balance is to be
-  // retrieved. Either a customer reference or a bank account reference will be
-  // provided. Only one of the two will be specified.
-  oneof reference {
-    // The combination of a reference type and reference number that uniquely
-    // identifies a bank customer. This field will be used if the customer is
-    // identified based on a unique resident identifier (like Aadhaar) or based
-    // on the customer's mobile number.
-    CustomerReference customer_reference = 1;
-    // A reference to uniquely identify a customer's bank account based on
-    // India's UPI standards.
-    AccountReference account_reference = 2;
+  // Payload for retrieve balance request.
+  message Payload {
+    // Identifies the customer or bank account whose account balance is to be
+    // retrieved. Either a customer reference or a bank account reference will
+    // be provided. Only one of the two will be specified.
+    oneof reference {
+      // The combination of a reference type and reference number that uniquely
+      // identifies a bank customer. This field will be used if the customer is
+      // identified based on a unique resident identifier (like Aadhaar) or
+      // based on the customer's mobile number.
+      CustomerReference customer_reference = 1;
+      // A reference to uniquely identify a customer's bank account based on
+      // India's UPI standards.
+      AccountReference account_reference = 2;
+    }
+    // Participant requesting the balance retrieval.
+    Participant participant = 3 [(google.api.field_behavior) = REQUIRED];
+    // Metadata about the API invocation received by the issuer switch which
+    // triggered this request to the bank adapter.
+    InvocationMetadata invocation_metadata = 4
+        [(google.api.field_behavior) = REQUIRED];
   }
-  // Participant requesting the balance retrieval.
-  Participant participant = 3 [(google.api.field_behavior) = REQUIRED];
-  // Metadata about the API invocation received by the issuer switch which
-  // triggered this request to the bank adapter.
-  InvocationMetadata invocation_metadata = 4
-      [(google.api.field_behavior) = REQUIRED];
+
+  // The request sent can be either a plain text request or encrypted in a
+  // Base64 encoded JSON string
+  oneof request {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.RetrieveBalanceRequest.Payload]
+    // message.
+    string encrypted = 2;
+  }
 }
 
 // Response for the RetrieveBalance method.
 message RetrieveBalanceResponse {
-  // Details of account balance.
-  BalanceInfo balance_info = 1 [(google.api.field_behavior) = REQUIRED];
-  // The account whose balance was retrieved.
-  AccountReference account_reference = 2
-      [(google.api.field_behavior) = REQUIRED];
+  // Payload for retrieve balance response.
+  message Payload {
+    // Details of account balance.
+    BalanceInfo balance_info = 1 [(google.api.field_behavior) = REQUIRED];
+    // The account whose balance was retrieved.
+    AccountReference account_reference = 2
+        [(google.api.field_behavior) = REQUIRED];
+    // Any additional metadata about the response from the bank adapter.
+    ResponseMetadata response_metadata = 3;
+  }
+
+  // The response sent can be either a plain text response or encrypted in a
+  // Base64 encoded JSON string
+  oneof response {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.RetrieveBalanceResponse.Payload]
+    // message.
+    string encrypted = 2;
+  }
 }

--- a/upi-india/issuer-switch/bank-adapter/spec/v1/common_types.proto
+++ b/upi-india/issuer-switch/bank-adapter/spec/v1/common_types.proto
@@ -1,10 +1,10 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//      https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,14 +14,14 @@
 
 syntax = "proto3";
 
-package google.cloud.paymentgateway.issuerswitch.bankadapter.v1;
+package google.cloud.paymentgateway.issuerswitch.adapter.bank.v1;
 
 import "google/api/field_behavior.proto";
 import "google/protobuf/timestamp.proto";
 
 option java_outer_classname = "CommonTypesProto";
 option java_multiple_files = true;
-option java_package = "com.google.cloud.paymentgateway.issuerswitch.bankadapter.v1";
+option java_package = "com.google.cloud.paymentgateway.issuerswitch.adapter.bank.v1";
 option go_api_flag = "OPAQUE_V0";
 
 // Provides additional reason about a particular error response returned by the
@@ -89,7 +89,7 @@ enum ErrorReason {
   SERVICE_ERROR = 22;
   // The requested operation could not be performed because the Bank Adapter
   // service or one or more of the bank's services are unavailable.
-  SERVICE_UNAVAILAIBLE = 23;
+  SERVICE_UNAVAILABLE = 23;
   // The requested transaction is not permitted.
   TRANSACTION_NOT_PERMITTED = 24;
   // The requested settle/resolve payment could not be performed because the
@@ -167,8 +167,8 @@ enum ErrorReason {
 
 // Unique identification of an account according to India's UPI standards.
 message AccountReference {
-  // IFSC code of a bank's branch.
-  string ifsc_code = 1 [(google.api.field_behavior) = REQUIRED];
+  // IFSC of an account's bank branch.
+  string ifsc = 1 [(google.api.field_behavior) = REQUIRED];
   // Type of account.
   string account_type = 2;
   // Unique number for the account in a bank and branch.
@@ -217,12 +217,13 @@ message Amount {
 
 // Risk information specific to India's UPI Standards.
 message RiskInfo {
-  // Entity providing the risk score.
+  // Entity providing the risk score. This could either be the payment service
+  // provider or the payment orchestrator.
   string risk_score_provider = 1;
   // Numeric value of risk evaluation ranging from 0 (No Risk) to 100 (Maximum
   // Risk).
   string risk_score_value = 2;
-  // Type of risk.
+  // Type of risk. Examples include `TXNRISK`.
   string risk_type = 3;
 }
 
@@ -238,41 +239,33 @@ enum Persona {
 
 // Details about the device that a participant in an API transaction is using.
 message DeviceDetails {
-  // Enumeration of the possible device information types.
-  enum DeviceInfoType {
-    // Unspecified device info type.
-    DEVICE_INFO_TYPE_UNSPECIFIED = 0;
-    // The name of the application running on the device.
-    DEVICE_INFO_TYPE_APPLICATION_NAME = 1;
-    // The device's capability.
-    DEVICE_INFO_TYPE_CAPABILITY = 2;
-    // The device's geocode.
-    DEVICE_INFO_TYPE_GEOCODE = 3;
-    // The device's ID.
-    DEVICE_INFO_TYPE_ID = 4;
-    // The device's IP address.
-    DEVICE_INFO_TYPE_IP = 5;
-    // The device's location.
-    DEVICE_INFO_TYPE_LOCATION = 6;
-    // The device's operating system (OS).
-    DEVICE_INFO_TYPE_OS = 7;
-    // The device type.
-    DEVICE_INFO_TYPE_DEVICE_TYPE = 8;
-    // The device's telecom provider.
-    DEVICE_INFO_TYPE_TELECOM_PROVIDER = 9;
-  }
+  // The payment application on the device.
+  string payment_app = 1;
 
-  // Information about a device.
-  message DeviceInfo {
-    // The type of the information.
-    DeviceInfoType type = 1 [(google.api.field_behavior) = REQUIRED];
-    // The value of the information.
-    string value = 2 [(google.api.field_behavior) = REQUIRED];
-  }
+  // The capability of the device.
+  string capability = 2;
 
-  // Information about the device. One or more of the types from the
-  // [DeviceInfoType][] will be included.
-  repeated DeviceInfo info = 1 [(google.api.field_behavior) = REQUIRED];
+  // The geo-code of the device. This will be a comma-separated value of the
+  // latitude and longitude of the device.
+  string geo_code = 3;
+
+  // The device's ID.
+  string id = 4;
+
+  // The device's IP address.
+  string ip_address = 5;
+
+  // The coarse location of the device.
+  string location = 6;
+
+  // The operating system on the device.
+  string operating_system = 7;
+
+  // The device's telecom provider.
+  string telecom_provider = 8;
+
+  // The type of device.
+  string type = 9;
 }
 
 // Information about a person or entity participating in a transaction.
@@ -291,14 +284,6 @@ message Participant {
       [(google.api.field_behavior) = REQUIRED];
   // Optional details of the device used by a participant in an API transaction.
   DeviceDetails device_details = 5;
-}
-
-// Provides additional informations about an entity.
-message AdditionalInfo {
-  // Field name.
-  string name = 1;
-  // Field value.
-  string value = 2;
 }
 
 // The name of a merchant who is a party in a payment settlement. Includes
@@ -377,7 +362,7 @@ message MerchantAdditionalInfo {
   // Indicates the type of ownership for the merchant.
   OwnershipType ownership_type = 7;
   // Additional information about the merchant.
-  repeated AdditionalInfo additional_info = 8;
+  map<string, string> additional_info = 8;
 }
 
 // Information about a merchant entity participating in a payment settlement.
@@ -539,9 +524,8 @@ message PaymentAdditionalInfo {
   ReferenceCategory reference_category = 10;
   // Risk information specific to India's UPI Standards.
   repeated RiskInfo risk_info = 11;
-  // Each additional info can be used to present more detailed information about
-  // the entity is attached to.
-  repeated AdditionalInfo miscellaneous = 12;
+  // More information about the payment.
+  map<string, string> miscellaneous = 12;
 }
 
 // Specifies the amount to be held and the holding rule.
@@ -733,4 +717,19 @@ message InvocationMetadata {
   // request received by the issuer switch.
   google.protobuf.Timestamp initiation_time = 2
       [(google.api.field_behavior) = REQUIRED];
+
+  // A reference id for the API invocation.
+  string reference_id = 3;
+
+  // A URL as a reference to the current API invocation.
+  string reference_url = 4;
+
+  // A descriptive note about the API transaction.
+  string description = 5;
+}
+
+// Metadata that the bank adapter wants to include in the response sent to the
+// issuer switch.
+message ResponseMetadata {
+  map<string, string> values = 1;
 }

--- a/upi-india/issuer-switch/bank-adapter/spec/v1/customer_types.proto
+++ b/upi-india/issuer-switch/bank-adapter/spec/v1/customer_types.proto
@@ -1,19 +1,20 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//      https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 syntax = "proto3";
 
-package google.cloud.paymentgateway.issuerswitch.bankadapter.v1;
+package google.cloud.paymentgateway.issuerswitch.adapter.bank.v1;
 
 import "cloud/api_products/payment_gateway/upi_india/bank_adapter/spec/issuer/v1/common_types.proto";
 import "google/api/field_behavior.proto";
@@ -21,7 +22,7 @@ import "google/type/date.proto";
 
 option java_outer_classname = "CustomerTypesProto";
 option java_multiple_files = true;
-option java_package = "com.google.cloud.paymentgateway.issuerswitch.bankadapter.v1";
+option java_package = "com.google.cloud.paymentgateway.issuerswitch.adapter.bank.v1";
 option go_api_flag = "OPAQUE_V0";
 
 // Information about a customer's debit/credit card that will be validated by
@@ -57,289 +58,429 @@ message CustomerValidationId {
 
 // Request body for customer notification.
 message NotifyCustomerRequest {
-  // Details of the MPIN update operation.
-  message MPINUpdated {
-    // Possible states of the MPIN update operation.
-    enum State {
-      // Unspecified state.
-      STATE_UNSPECIFIED = 0;
-      // MPIN update succeeded.
-      SUCCEEDED = 1;
-      // MPIN update failed.
-      FAILED = 2;
+  // Payload for notify customer request.
+  message Payload {
+    // Details of the MPIN update operation.
+    message MPINUpdated {
+      // Possible states of the MPIN update operation.
+      enum State {
+        // Unspecified state.
+        STATE_UNSPECIFIED = 0;
+        // MPIN update succeeded.
+        SUCCEEDED = 1;
+        // MPIN update failed.
+        FAILED = 2;
+      }
+      // State of the MPIN update operation.
+      State state = 1 [(google.api.field_behavior) = REQUIRED];
     }
-    // State of the MPIN update operation.
-    State state = 1 [(google.api.field_behavior) = REQUIRED];
+    // Details of the notification needed for recurring mandate (auto-pay)
+    // operations.
+    message RecurringMandate {
+      // Possible states of the recurrming mandate operation.
+      enum State {
+        // Unspecified state.
+        STATE_UNSPECIFIED = 0;
+        // Recurring mandate operation succeeded.
+        SUCCEEDED = 1;
+        // Recurring mandate operation failed.
+        FAILED = 2;
+      }
+      // Recurrence pattern of the mandate.
+      enum Pattern {
+        // Unspecified recurrence pattern.
+        PATTERN_UNSPECIFIED = 0;
+        // Mandate recurring daily.
+        PATTERN_DAILY = 1;
+        // Mandate recurring weekly.
+        PATTERN_WEEKLY = 2;
+        // Mandate recurring fortnightly.
+        PATTERN_FORTNIGHTLY = 3;
+        // Mandate recurring monthly.
+        PATTERN_MONTHLY = 4;
+        // Mandate recurring bi-monthly (once every 2 months).
+        PATTERN_BIMONTHLY = 5;
+        // Mandate recurring quarterly.
+        PATTERN_QUARTERLY = 6;
+        // Mandate recurring half yearly.
+        PATTERN_HALFYEARLY = 7;
+        // Mandate recurring yearly.
+        PATTERN_YEARLY = 8;
+      }
+      // Identifier of the mandate. This maps to the `Unique Mandate Number
+      // (UMN)` in India's UPI standards.
+      string id = 1 [(google.api.field_behavior) = REQUIRED];
+      // Information about the payee who will be executing the mandate debit
+      // request. This will include the payee's VPA, name and all merchant
+      // details of the payee. Note that the account reference of the payee will
+      // not be populated in the request.
+      SettlementParticipant payee = 2 [(google.api.field_behavior) = REQUIRED];
+      // The mandate's recurrence pattern.
+      Pattern pattern = 3 [(google.api.field_behavior) = REQUIRED];
+      // The amount that will be settled as part of the mandate execution.
+      Amount amount = 4 [(google.api.field_behavior) = REQUIRED];
+      // State of the recurring mandate operation.
+      State state = 5 [(google.api.field_behavior) = REQUIRED];
+      // Type of operation performed on the recurring mandate.
+      OperationType operation_type = 6 [(google.api.field_behavior) = REQUIRED];
+      // Details of a newly created recurring mandate.
+      message Creation {
+        // Start date of the recurring mandate.
+        google.type.Date start_date = 1
+            [(google.api.field_behavior) = REQUIRED];
+        // End date of the recurring mandate.
+        google.type.Date end_date = 2 [(google.api.field_behavior) = REQUIRED];
+      }
+      // Details of a recurring mandate that is to be executed in the next 24
+      // hours with a SettlePayment-DEBIT.
+      message Execution {
+        // Date when the mandate will be executed next.
+        google.type.Date execution_date = 1
+            [(google.api.field_behavior) = REQUIRED];
+      }
+      // Details of a recurring mandate that has been modified.
+      message Modification {
+        // Modified start date of the recurring mandate.
+        google.type.Date start_date = 1
+            [(google.api.field_behavior) = REQUIRED];
+        // Modified end date of the recurring mandate.
+        google.type.Date end_date = 2 [(google.api.field_behavior) = REQUIRED];
+      }
+      // Detailf of a recurring mandate that has been paused.
+      message Pause {
+        // Date when the recurring mandate's pause starts.
+        google.type.Date start_date = 1
+            [(google.api.field_behavior) = REQUIRED];
+        // Date when the recurring mandate's pause ends.
+        google.type.Date end_date = 2 [(google.api.field_behavior) = REQUIRED];
+      }
+      enum OperationType {
+        // Unspecified operation type.
+        OPERATION_TYPE_UNSPECIFIED = 0;
+        // Operation type creation. This type indicates that a new recurring
+        // mandate creation operation has been processed by the issuer switch.
+        // The `operation` field will contain details about the newly created
+        // mandate.
+        OPERATION_TYPE_CREATION = 1;
+        // Operation type execution. This type indicates that there will be an
+        // upcoming execution of a recurring mandate. The `operation` field will
+        // contain details about the upcoming execution of the recurring
+        // mandate.
+        OPERATION_TYPE_EXECUTION = 2;
+        // Operation type modification. This type indicates that the issuer
+        // switch has processed a modification to a recurring mandate. The
+        // `operation` field will contain details about the modified recurring
+        // mandate.
+        OPERATION_TYPE_MODIFICATION = 3;
+        // Operation type revocation. This type indicates that the issuer switch
+        // has processed a revocation of a recurring mandate. No additional
+        // information is included for this operation type.
+        OPERATION_TYPE_REVOCATION = 4;
+        // Operation type pause. This type indicates that the issuer switch has
+        // processed a pause on a recurring mandate. The `operation` field will
+        // contain details about pause operation.
+        OPERATION_TYPE_PAUSE = 5;
+        // Operation type unpause. This type indicates that the issuer switch
+        // has processed an unpause on a recurring mandate. No additional
+        // information is included for this operation type.
+        OPERATION_TYPE_UNPAUSE = 6;
+      }
+      // Additional information about the operation processed on a recurring
+      // mandate will be provided in this field. One of these values will be
+      // specified.
+      oneof Operation {
+        // Contains details about the recurring mandate creation operation.
+        Creation creation = 7;
+        // Contains details about the recurring mandate execution operation.
+        Execution execution = 8;
+        // Contains details about the recurring mandate modification operation.
+        Modification modification = 9;
+        // Contains details about the recurring mandate pause operation.
+        Pause pause = 10;
+      }
+    }
+    // Participant to be notified.
+    Participant participant = 1 [(google.api.field_behavior) = REQUIRED];
+    // Unique identification of an account according to India's UPI standards.
+    // This is the details of the account of the customer who is to be notified.
+    AccountReference account = 2 [(google.api.field_behavior) = REQUIRED];
+    // The details of the notification. Exactly one of two values will be
+    // specified. The type of notification to be sent can be inferred from which
+    // of the two possible values are set in the request.
+    oneof details {
+      // Details of the MPIN operation processed by the issuer switch.
+      MPINUpdated mpin_updated = 3;
+      // Details of the recurring mandate operation processed by the issuer
+      // switch.
+      RecurringMandate recurring_mandate = 4;
+    }
+    // Metadata about the API invocation received by the issuer switch which
+    // triggered this request to the bank adapter.
+    InvocationMetadata invocation_metadata = 5
+        [(google.api.field_behavior) = REQUIRED];
   }
-  // Details of the notification needed for recurring mandate (auto-pay)
-  // operations.
-  message RecurringMandate {
-    // Possible states of the recurrming mandate operation.
-    enum State {
-      // Unspecified state.
-      STATE_UNSPECIFIED = 0;
-      // Recurring mandate operation succeeded.
-      SUCCEEDED = 1;
-      // Recurring mandate operation failed.
-      FAILED = 2;
-    }
-    // Recurrence pattern of the mandate.
-    enum Pattern {
-      // Unspecified recurrence pattern.
-      PATTERN_UNSPECIFIED = 0;
-      // Mandate recurring daily.
-      PATTERN_DAILY = 1;
-      // Mandate recurring weekly.
-      PATTERN_WEEKLY = 2;
-      // Mandate recurring fortnightly.
-      PATTERN_FORTNIGHTLY = 3;
-      // Mandate recurring monthly.
-      PATTERN_MONTHLY = 4;
-      // Mandate recurring bi-monthly (once every 2 months).
-      PATTERN_BIMONTHLY = 5;
-      // Mandate recurring quarterly.
-      PATTERN_QUARTERLY = 6;
-      // Mandate recurring half yearly.
-      PATTERN_HALFYEARLY = 7;
-      // Mandate recurring yearly.
-      PATTERN_YEARLY = 8;
-    }
-    // Identifier of the mandate. This maps to the `Unique Mandate Number (UMN)`
-    // in India's UPI standards.
-    string id = 1 [(google.api.field_behavior) = REQUIRED];
-    // Information about the payee who will be executing the mandate debit
-    // request. This will include the payee's VPA, name and all merchant details
-    // of the payee. Note that the account reference of the payee will not be
-    // populated in the request.
-    SettlementParticipant payee = 2 [(google.api.field_behavior) = REQUIRED];
-    // The mandate's recurrence pattern.
-    Pattern pattern = 3 [(google.api.field_behavior) = REQUIRED];
-    // The amount that will be settled as part of the mandate execution.
-    Amount amount = 4 [(google.api.field_behavior) = REQUIRED];
-    // State of the recurring mandate operation.
-    State state = 5 [(google.api.field_behavior) = REQUIRED];
-    // Type of operation performed on the recurring mandate.
-    OperationType operation_type = 6 [(google.api.field_behavior) = REQUIRED];
-    // Details of a newly created recurring mandate.
-    message Creation {
-      // Start date of the recurring mandate.
-      google.type.Date start_date = 1 [(google.api.field_behavior) = REQUIRED];
-      // End date of the recurring mandate.
-      google.type.Date end_date = 2 [(google.api.field_behavior) = REQUIRED];
-    }
-    // Details of a recurring mandate that is to be executed in the next 24
-    // hours with a SettlePayment-DEBIT.
-    message Execution {
-      // Date when the mandate will be executed next.
-      google.type.Date execution_date = 1
-          [(google.api.field_behavior) = REQUIRED];
-    }
-    // Details of a recurring mandate that has been modified.
-    message Modification {
-      // Modified start date of the recurring mandate.
-      google.type.Date start_date = 1 [(google.api.field_behavior) = REQUIRED];
-      // Modified end date of the recurring mandate.
-      google.type.Date end_date = 2 [(google.api.field_behavior) = REQUIRED];
-    }
-    // Detailf of a recurring mandate that has been paused.
-    message Pause {
-      // Date when the recurring mandate's pause starts.
-      google.type.Date start_date = 1 [(google.api.field_behavior) = REQUIRED];
-      // Date when the recurring mandate's pause ends.
-      google.type.Date end_date = 2 [(google.api.field_behavior) = REQUIRED];
-    }
-    enum OperationType {
-      // Unspecified operation type.
-      OPERATION_TYPE_UNSPECIFIED = 0;
-      // Operation type creation. This type indicates that a new recurring
-      // mandate creation operation has been processed by the issuer switch. The
-      // `operation` field will contain details about the newly created mandate.
-      OPERATION_TYPE_CREATION = 1;
-      // Operation type execution. This type indicates that there will be an
-      // upcoming execution of a recurring mandate. The `operation` field will
-      // contain details about the upcoming execution of the recurring mandate.
-      OPERATION_TYPE_EXECUTION = 2;
-      // Operation type modification. This type indicates that the issuer switch
-      // has processed a modification to a recurring mandate. The `operation`
-      // field will contain details about the modified recurring mandate.
-      OPERATION_TYPE_MODIFICATION = 3;
-      // Operation type revocation. This type indicates that the issuer switch
-      // has processed a revocation of a recurring mandate. No additional
-      // information is included for this operation type.
-      OPERATION_TYPE_REVOCATION = 4;
-      // Operation type pause. This type indicates that the issuer switch has
-      // processed a pause on a recurring mandate. The `operation` field will
-      // contain details about pause operation.
-      OPERATION_TYPE_PAUSE = 5;
-      // Operation type unpause. This type indicates that the issuer switch has
-      // processed an unpause on a recurring mandate. No additional information
-      // is included for this operation type.
-      OPERATION_TYPE_UNPAUSE = 6;
-    }
-    // Additional information about the operation processed on a recurring
-    // mandate will be provided in this field. One of these values will be
-    // specified.
-    oneof Operation {
-      // Contains details about the recurring mandate creation operation.
-      Creation creation = 7;
-      // Contains details about the recurring mandate execution operation.
-      Execution execution = 8;
-      // Contains details about the recurring mandate modification operation.
-      Modification modification = 9;
-      // Contains details about the recurring mandate pause operation.
-      Pause pause = 10;
-    }
+
+  // The request sent can be either a plain text request or encrypted in a
+  // Base64 encoded JSON string
+  oneof request {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.NotifyCustomerRequest.Payload]
+    // message.
+    string encrypted = 2;
   }
-  // Participant to be notified.
-  Participant participant = 1 [(google.api.field_behavior) = REQUIRED];
-  // Unique identification of an account according to India's UPI standards.
-  // This is the details of the account of the customer who is to be notified.
-  AccountReference account = 2 [(google.api.field_behavior) = REQUIRED];
-  // The details of the notification. Exactly one of two values will be
-  // specified. The type of notification to be sent can be inferred from which
-  // of the two possible values are set in the request.
-  oneof details {
-    // Details of the MPIN operation processed by the issuer switch.
-    MPINUpdated mpin_updated = 3;
-    // Details of the recurring mandate operation processed by the issuer
-    // switch.
-    RecurringMandate recurring_mandate = 4;
+}
+
+// Response for a customer notification.
+message NotifyCustomerResponse {
+  // Payload for the customer notification response.
+  message Payload {
+    // Any additional metadata about the response from the bank adapter.
+    ResponseMetadata response_metadata = 1;
   }
-  // Metadata about the API invocation received by the issuer switch which
-  // triggered this request to the bank adapter.
-  InvocationMetadata invocation_metadata = 5
-      [(google.api.field_behavior) = REQUIRED];
+  // The response sent can be either a plain text response or encrypted in a
+  // Base64 encoded JSON string
+  oneof response {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.ReleaseFundsResponse.Payload]
+    // message.
+    string encrypted = 2;
+  }
 }
 
 // The response once a registration request has been processed and an OTP has
 // been generated and sent to a customer's mobile phone.
 message InitiateRegistrationResponse {
-  // URL the customer should use to enter the OTP received on their mobile.
-  string validation_page_link = 1;
+  // Payload for initiate registration response.
+  message Payload {
+    // URL the customer should use to enter the OTP received on their mobile.
+    string validation_page_link = 1;
+    // Any additional metadata about the response from the bank adapter.
+    ResponseMetadata response_metadata = 2;
+  }
+
+  // The response sent can be either a plain text response or encrypted in a
+  // Base64 encoded JSON string
+  oneof response {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.InitiateRegistrationResponse.Payload]
+    // message.
+    string encrypted = 2;
+  }
 }
 
 // Request for initiating registration of a customer's bank account for UPI.
 message InitiateRegistrationRequest {
-  // Identifies the customer or bank account registering for UPI. An OTP is sent
-  // to the mobile number associated with the customer/bank account. Either a
-  // customer reference or a bank account reference will be provided. Only one
-  // of the two will be specified.
-  oneof reference {
-    // The combination of a reference type and reference number that uniquely
-    // identifies a bank customer. This field will be used if the customer is
-    // identified based on a unique resident identifier (like Aadhaar) or based
-    // on the customer's mobile number.
-    CustomerReference customer_reference = 1;
-    // A reference to uniquely identify a customer's bank account based on
-    // India's UPI standards.
-    AccountReference account_reference = 2;
+  // Payload for initiate registration request.
+  message Payload {
+    // Identifies the customer or bank account registering for UPI. An OTP is
+    // sent to the mobile number associated with the customer/bank account.
+    // Either a customer reference or a bank account reference will be provided.
+    // Only one of the two will be specified.
+    oneof reference {
+      // The combination of a reference type and reference number that uniquely
+      // identifies a bank customer. This field will be used if the customer is
+      // identified based on a unique resident identifier (like Aadhaar) or
+      // based on the customer's mobile number.
+      CustomerReference customer_reference = 1;
+      // A reference to uniquely identify a customer's bank account based on
+      // India's UPI standards.
+      AccountReference account_reference = 2;
+    }
+    // Information about a customer's debit/credit card that will be provided if
+    // the issuer bank supports the ATM_REDIRECT mode of registration.
+    CardInfo card_info = 3;
+    // Participant initiating the registration.
+    Participant participant = 4 [(google.api.field_behavior) = REQUIRED];
+    // The type of registration indicating if the specified reference is being
+    // registered newly or being reset.
+    RegistrationType type = 5 [(google.api.field_behavior) = REQUIRED];
+    // Metadata about the API invocation received by the issuer switch which
+    // triggered this request to the bank adapter.
+    InvocationMetadata invocation_metadata = 6
+        [(google.api.field_behavior) = REQUIRED];
   }
-  // Information about a customer's debit/credit card that will be provided if
-  // the issuer bank supports the ATM_REDIRECT mode of registration.
-  CardInfo card_info = 3;
-  // Participant initiating the registration.
-  Participant participant = 4 [(google.api.field_behavior) = REQUIRED];
-  // The type of registration indicating if the specified reference is being
-  // registered newly or being reset.
-  RegistrationType type = 5 [(google.api.field_behavior) = REQUIRED];
-  // Metadata about the API invocation received by the issuer switch which
-  // triggered this request to the bank adapter.
-  InvocationMetadata invocation_metadata = 6
-      [(google.api.field_behavior) = REQUIRED];
+
+  // The request sent can be either a plain text request or encrypted in a
+  // Base64 encoded JSON string
+  oneof request {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.InitiateRegistrationRequest.Payload]
+    // message.
+    string encrypted = 2;
+  }
 }
 
 // Request for a previously initiated registration to be validated.
 message ValidateRegistrationRequest {
-  // Identifies the customer or bank account whose registration for UPI is to be
-  // validated. Either a customer reference or a bank account reference will be
-  // provided. Only one of the two will be specified.
-  oneof reference {
-    // The combination of a reference type and reference number that uniquely
-    // identifies a bank customer. This field will be used if the customer is
-    // identified based on a unique resident identifier (like Aadhaar) or based
-    // on the customer's mobile number.
-    CustomerReference customer_reference = 1;
-    // A reference to uniquely identify a customer's bank account based on
-    // India's UPI standards.
-    AccountReference account_reference = 2;
+  // Payload for validate registration request.
+  message Payload {
+    // Identifies the customer or bank account whose registration for UPI is to
+    // be validated. Either a customer reference or a bank account reference
+    // will be provided. Only one of the two will be specified.
+    oneof reference {
+      // The combination of a reference type and reference number that uniquely
+      // identifies a bank customer. This field will be used if the customer is
+      // identified based on a unique resident identifier (like Aadhaar) or
+      // based on the customer's mobile number.
+      CustomerReference customer_reference = 1;
+      // A reference to uniquely identify a customer's bank account based on
+      // India's UPI standards.
+      AccountReference account_reference = 2;
+    }
+    // Information about a customer's debit/credit card that needs to be
+    // validated by the bank. This value will be specified only if the
+    // registration is being validated with a debit/credit card.
+    //
+    // If the registration is validated using an Aadhaar OTP, then this field
+    // will be omitted.
+    CardInfo card_info = 3;
+    // The PIN for the debit/credit card that needs to be validated by the
+    // bank. This value will be specified only if the registration is being
+    // validated with a debit/credit card.
+    //
+    // If the registration is validated using an Aadhaar OTP, then this field
+    // will be omitted.
+    string pin = 4;
+    // The OTP received on the customer's mobile phone that needs to be
+    // validated by the bank.
+    string otp = 5 [(google.api.field_behavior) = REQUIRED];
+    // Participant validating the registration.
+    Participant participant = 6 [(google.api.field_behavior) = REQUIRED];
+    // The type of registration indicating if the specified reference is being
+    // registered newly or being reset.
+    RegistrationType type = 7 [(google.api.field_behavior) = REQUIRED];
+    // Metadata about the API invocation received by the issuer switch which
+    // triggered this request to the bank adapter.
+    InvocationMetadata invocation_metadata = 8
+        [(google.api.field_behavior) = REQUIRED];
   }
-  // Information about a customer's debit/credit card that needs to be validated
-  // by the bank. This value will be specified only if the registration is being
-  // validated with a debit/credit card.
-  //
-  // If the registration is validated using an Aadhaar OTP, then this field will
-  // be omitted.
-  CardInfo card_info = 3;
-  // The PIN for the debit/credit card that needs to be validated by the
-  // bank. This value will be specified only if the registration is being
-  // validated with a debit/credit card.
-  //
-  // If the registration is validated using an Aadhaar OTP, then this field will
-  // be omitted.
-  string pin = 4;
-  // The OTP received on the customer's mobile phone that needs to be validated
-  // by the bank.
-  string otp = 5 [(google.api.field_behavior) = REQUIRED];
-  // Participant validating the registration.
-  Participant participant = 6 [(google.api.field_behavior) = REQUIRED];
-  // The type of registration indicating if the specified reference is being
-  // registered newly or being reset.
-  RegistrationType type = 7 [(google.api.field_behavior) = REQUIRED];
-  // Metadata about the API invocation received by the issuer switch which
-  // triggered this request to the bank adapter.
-  InvocationMetadata invocation_metadata = 8
-      [(google.api.field_behavior) = REQUIRED];
+
+  // The request sent can be either a plain text request or encrypted in a
+  // Base64 encoded JSON string
+  oneof request {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.ValidateRegistrationRequest.Payload]
+    // message.
+    string encrypted = 2;
+  }
+}
+
+// Response for a request to validate a previously initiated registration.
+message ValidateRegistrationResponse {
+  // Payload for the validate registration response.
+  message Payload {
+    // Any additional metadata about the response from the bank adapter.
+    ResponseMetadata response_metadata = 1;
+  }
+  // The response sent can be either a plain text response or encrypted in a
+  // Base64 encoded JSON string
+  oneof response {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.ReleaseFundsResponse.Payload]
+    // message.
+    string encrypted = 2;
+  }
 }
 
 // Request for validating customer against a government issued ID.
 message CustomerValidationRequest {
-  // Details of the ID that needs to be validated.
-  CustomerValidationId id = 1 [(google.api.field_behavior) = REQUIRED];
-  // Unique identification of an account according to India's UPI standards.
-  AccountReference ref = 2 [(google.api.field_behavior) = REQUIRED];
-  // Metadata about the API invocation received by the issuer switch which
-  // triggered this request to the bank adapter.
-  InvocationMetadata invocation_metadata = 3
-      [(google.api.field_behavior) = REQUIRED];
+  // Payload for customer validation request.
+  message Payload {
+    // Details of the ID that needs to be validated.
+    CustomerValidationId id = 1 [(google.api.field_behavior) = REQUIRED];
+    // Unique identification of an account according to India's UPI standards.
+    AccountReference ref = 2 [(google.api.field_behavior) = REQUIRED];
+    // Metadata about the API invocation received by the issuer switch which
+    // triggered this request to the bank adapter.
+    InvocationMetadata invocation_metadata = 3
+        [(google.api.field_behavior) = REQUIRED];
+  }
+
+  // The request sent can be either a plain text request or encrypted in a
+  // Base64 encoded JSON string
+  oneof request {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.CustomerValidationRequest.Payload]
+    // message.
+    string encrypted = 2;
+  }
 }
 
 // Response for the customer validation against a government ID.
 message CustomerValidationResponse {
-  // Types of account nature.
-  enum AccountNature {
-    // Unspecified account nature.
-    ACCOUNT_NATURE_UNDEFINED = 0;
-    // Acount nature is of type SINGLE.
-    SINGLE = 1;
-    // Account nature is of type JOINT.
-    JOINT = 2;
+  // Payload for customer validation response.
+  message Payload {
+    // Types of account nature.
+    enum AccountNature {
+      // Unspecified account nature.
+      ACCOUNT_NATURE_UNDEFINED = 0;
+      // Acount nature is of type SINGLE.
+      SINGLE = 1;
+      // Account nature is of type JOINT.
+      JOINT = 2;
+    }
+
+    // Types of account holder.
+    enum AccountHolder {
+      // Unspecified account holder.
+      ACCOUNT_HOLDER_UNDEFINED = 0;
+      // Customer is primary account holder.
+      PRIMARY = 1;
+      // Customer is secondary account holder.
+      SECONDARY = 2;
+    }
+
+    // TRUE if the ID provided in the request is valid, FALSE otherwise.
+    bool valid = 1 [(google.api.field_behavior) = REQUIRED];
+    // Nature of the account i.e. SINGLE/JOINT.
+    AccountNature account_nature = 2 [(google.api.field_behavior) = REQUIRED];
+    // Denotes whether the customer is a PRIMARY or SECONDARY account holder.
+    AccountHolder account_holder = 3 [(google.api.field_behavior) = REQUIRED];
+    // Denotes whether the account type is SAVINGS, CURRENT etc.
+    string account_type = 4 [(google.api.field_behavior) = REQUIRED];
+    // Mask Name of the customer with the bank.
+    string mask_name = 5;
+    // Denotes whether Customer is a PERSON or ENTITY.
+    Persona customer_type = 6 [(google.api.field_behavior) = REQUIRED];
+    // Merchant Category code as specified by UPI (A four-digit number listed in
+    // ISO 18245 for retail financial services).
+    string category_code = 7;
+    // Any additional metadata about the response from the bank adapter.
+    ResponseMetadata response_metadata = 8;
   }
 
-  // Types of account holder.
-  enum AccountHolder {
-    // Unspecified account holder.
-    ACCOUNT_HOLDER_UNDEFINED = 0;
-    // Customer is primary account holder.
-    PRIMARY = 1;
-    // Customer is secondary account holder.
-    SECONDARY = 2;
+  // The response sent can be either a plain text response or encrypted in a
+  // Base64 encoded JSON string
+  oneof response {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.CustomerValidationResponse.Payload]
+    // message.
+    string encrypted = 2;
   }
-
-  // TRUE if the ID provided in the request is valid, FALSE otherwise.
-  bool valid = 1 [(google.api.field_behavior) = REQUIRED];
-  // Nature of the account i.e. SINGLE/JOINT.
-  AccountNature account_nature = 2 [(google.api.field_behavior) = REQUIRED];
-  // Denotes whether the customer is a PRIMARY or SECONDARY account holder.
-  AccountHolder account_holder = 3 [(google.api.field_behavior) = REQUIRED];
-  // Denotes whether the account type is SAVINGS, CURRENT etc.
-  string account_type = 4 [(google.api.field_behavior) = REQUIRED];
-  // Mask Name of the customer with the bank.
-  string mask_name = 5;
-  // Denotes whether Customer is a PERSON or ENTITY.
-  Persona customer_type = 6 [(google.api.field_behavior) = REQUIRED];
-  // Merchant Category code as specified by UPI (A four-digit number listed in
-  // ISO 18245 for retail financial services).
-  string category_code = 7;
 }
 
 // Enumeration of the types of registration.

--- a/upi-india/issuer-switch/bank-adapter/spec/v1/issuer_bank_adapter_service.proto
+++ b/upi-india/issuer-switch/bank-adapter/spec/v1/issuer_bank_adapter_service.proto
@@ -1,10 +1,10 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//      https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,18 +14,17 @@
 
 syntax = "proto3";
 
-package google.cloud.paymentgateway.issuerswitch.bankadapter.v1;
+package google.cloud.paymentgateway.issuerswitch.adapter.bank.v1;
 
 import "cloud/api_products/payment_gateway/upi_india/bank_adapter/spec/issuer/v1/account_types.proto";
 import "cloud/api_products/payment_gateway/upi_india/bank_adapter/spec/issuer/v1/customer_types.proto";
 import "cloud/api_products/payment_gateway/upi_india/bank_adapter/spec/issuer/v1/payment_settlement_types.proto";
 import "cloud/api_products/payment_gateway/upi_india/bank_adapter/spec/issuer/v1/resolution_types.proto";
 import "google/api/annotations.proto";
-import "google/protobuf/empty.proto";
 
 option java_outer_classname = "IssuerBankAdapterServiceProto";
 option java_multiple_files = true;
-option java_package = "com.google.cloud.paymentgateway.issuerswitch.bankadapter.v1";
+option java_package = "com.google.cloud.paymentgateway.issuerswitch.adapter.bank.v1";
 option go_api_flag = "OPAQUE_V0";
 
 // A service interface for the Issuer Switch Bank Adapter.
@@ -171,7 +170,7 @@ service BankAdapterService {
   //
   // _Note:_ This API will be invoked in the UPI `ReqMandate` and `ReqVoucher`
   // API flows.
-  rpc ReleaseFunds(ReleaseFundsRequest) returns (google.protobuf.Empty) {
+  rpc ReleaseFunds(ReleaseFundsRequest) returns (ReleaseFundsResponse) {
     option (google.api.http) = {
       post: "/v1/accounts/funds:release"
       body: "*"
@@ -457,7 +456,7 @@ service BankAdapterService {
   //
   // _Note:_ This API will be invoked in the UPI `ReqRegMob` API flow.
   rpc ValidateRegistration(ValidateRegistrationRequest)
-      returns (google.protobuf.Empty) {
+      returns (ValidateRegistrationResponse) {
     option (google.api.http) = {
       post: "/v1/users:validateRegistration"
       body: "*"
@@ -530,7 +529,7 @@ service BankAdapterService {
   //
   // _Note:_ This API will be invoked in the UPI `ReqSetCre` API flow, or in the
   // `ReqValCust` (mandate notification) API flow.
-  rpc NotifyCustomer(NotifyCustomerRequest) returns (google.protobuf.Empty) {
+  rpc NotifyCustomer(NotifyCustomerRequest) returns (NotifyCustomerResponse) {
     option (google.api.http) = {
       post: "/v1/users:notifyCustomer"
       body: "*"

--- a/upi-india/issuer-switch/bank-adapter/spec/v1/payment_settlement_types.proto
+++ b/upi-india/issuer-switch/bank-adapter/spec/v1/payment_settlement_types.proto
@@ -1,10 +1,10 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//      https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-package google.cloud.paymentgateway.issuerswitch.bankadapter.v1;
+package google.cloud.paymentgateway.issuerswitch.adapter.bank.v1;
 
 import "cloud/api_products/payment_gateway/upi_india/bank_adapter/spec/issuer/v1/common_types.proto";
 import "google/api/field_behavior.proto";
@@ -22,65 +22,124 @@ import "google/protobuf/timestamp.proto";
 
 option java_outer_classname = "PaymentSettlementTypesProto";
 option java_multiple_files = true;
-option java_package = "com.google.cloud.paymentgateway.issuerswitch.bankadapter.v1";
+option java_package = "com.google.cloud.paymentgateway.issuerswitch.adapter.bank.v1";
 option go_api_flag = "OPAQUE_V0";
 
 // Individual payment settlement request.
 message SettlePaymentRequest {
-  // Type of settlement to execute.
-  SettlementType settlement_type = 1 [(google.api.field_behavior) = REQUIRED];
-  // Payer in the payment settlement transaction. This field is present in all
-  // requests, except when the *settlement type* is
-  // [CREDIT_REVERSAL][google.cloud.paymentgateway.issuerswitch.bankadapter.v1.SettlementType.CREDIT_REVERSAL].
-  SettlementParticipant payer = 2;
-  // Payee in the settlement payment transaction. This field is present in all
-  // requests, except when the *settlement type* is
-  // [DEBIT_REVERSAL][google.cloud.paymentgateway.issuerswitch.bankadapter.v1.SettlementType.DEBIT_REVERSAL].
-  SettlementParticipant payee = 3;
-  // Amount needed to complete payment settlement.
-  Amount instructed_amount = 4 [(google.api.field_behavior) = REQUIRED];
-  // Uniquely identifies the payment this settlement is part of. This maps to
-  // the transaction id in India's UPI system.
-  string payment_id = 5 [(google.api.field_behavior) = REQUIRED];
-  // Retrieval Reference Number (RRN) for the transaction.
-  string retrieval_reference_number = 6
-      [(google.api.field_behavior) = REQUIRED];
-  // Free form string providing a description of the payment settlement.
-  string description = 7 [(google.api.field_behavior) = REQUIRED];
-  // Specifies the amount held and the holding reference i.e. the bank's
-  // reference for the funds held in the account which are being debited or
-  // reversed in this request. A value will be specified for this field only for
-  // `DEBIT` settlements which are initiated against funds held in the account
-  // or `DEBIT_REVERSAL` settlements which are initiated against deemed `DEBIT`
-  // settlements.
-  HoldDetails hold_details = 8;
-  // Timestamp of the current request.
-  google.protobuf.Timestamp request_time = 9
-      [(google.api.field_behavior) = REQUIRED];
-  // Additional information about the payment settlement.
-  PaymentAdditionalInfo additional_info = 10;
-  // If this request's _settlement type_ is `DEBIT_REVERSAL` or
-  // `CREDIT_REVERSAL`, then details of the original transaction that is being
-  // reversed will be provided in this field.
-  OriginalTransaction original_transaction = 11;
-  // If this request is being triggered as part of a complaint raised via UPI's
-  // UDIR system, then details of the complaint will be available in this field.
-  CaseDetails case_details = 12;
-  // Metadata about the API invocation received by the issuer switch which
-  // triggered this request to the bank adapter.
-  InvocationMetadata invocation_metadata = 13
-      [(google.api.field_behavior) = REQUIRED];
+  // Payload for settle payment request.
+  message Payload {
+    // Type of settlement to execute.
+    SettlementType settlement_type = 1 [(google.api.field_behavior) = REQUIRED];
+    // Payer in the payment settlement transaction. This field is present in all
+    // requests, except when the *settlement type* is
+    // [CREDIT_REVERSAL][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.SettlementType.CREDIT_REVERSAL].
+    SettlementParticipant payer = 2;
+    // Payee in the settlement payment transaction. This field is present in all
+    // requests, except when the *settlement type* is
+    // [DEBIT_REVERSAL][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.SettlementType.DEBIT_REVERSAL].
+    SettlementParticipant payee = 3;
+    // Amount needed to complete payment settlement.
+    Amount instructed_amount = 4 [(google.api.field_behavior) = REQUIRED];
+    // Uniquely identifies the payment this settlement is part of. This maps to
+    // the transaction id in India's UPI system.
+    string payment_id = 5 [(google.api.field_behavior) = REQUIRED];
+    // Retrieval Reference Number (RRN) for the transaction.
+    string retrieval_reference_number = 6
+        [(google.api.field_behavior) = REQUIRED];
+    // Free form string providing a description of the payment settlement.
+    string description = 7 [(google.api.field_behavior) = REQUIRED];
+    // Specifies the amount held and the holding reference i.e. the bank's
+    // reference for the funds held in the account which are being debited or
+    // reversed in this request. A value will be specified for this field only
+    // for `DEBIT` settlements which are initiated against funds held in the
+    // account or `DEBIT_REVERSAL` settlements which are initiated against
+    // deemed `DEBIT` settlements.
+    HoldDetails hold_details = 8;
+    // Timestamp of the current request.
+    google.protobuf.Timestamp request_time = 9
+        [(google.api.field_behavior) = REQUIRED];
+    // Additional information about the payment settlement.
+    PaymentAdditionalInfo additional_info = 10;
+    // If this request's _settlement type_ is `DEBIT_REVERSAL` or
+    // `CREDIT_REVERSAL`, then details of the original transaction that is being
+    // reversed will be provided in this field.
+    OriginalTransaction original_transaction = 11;
+    // If this request is being triggered as part of a complaint raised via
+    // UPI's UDIR system, then details of the complaint will be available in
+    // this field.
+    CaseDetails case_details = 12;
+    // Metadata about the API invocation received by the issuer switch which
+    // triggered this request to the bank adapter.
+    InvocationMetadata invocation_metadata = 13
+        [(google.api.field_behavior) = REQUIRED];
+
+    // A payment rule as provided by the payments orchestrator.
+    message Rule {
+      // An enum of the possible rule names.
+      enum RuleName {
+        // Rule name unspecified.
+        RULE_NAME_UNSPECIFIED = 0;
+        // The `expire after` rule.
+        EXPIRE_AFTER = 1;
+        // The `min amount` rule.
+        MIN_AMOUNT = 2;
+      }
+      // The rule's name.
+      RuleName name = 1;
+      // The rule's value.
+      string value = 2;
+    }
+    // A list of rules specified by the payments orchestrator for the payment
+    // settlement.
+    repeated Rule rules = 14;
+  }
+
+  // The request sent can be either a plain text request or encrypted in a
+  // Base64 encoded JSON string
+  oneof request {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.SettlePaymentRequest.Payload]
+    // message.
+    string encrypted = 2;
+  }
+}
+
+// Information about a successful payment settlement.
+message SettlePaymentInfo {
+  // An identifier used by the bank's systems for the settlement operation. In
+  // India's UPI system, this translates to the `approval number`. This value
+  // is alpha-numeric and should be exactly 6 characters long.
+  string backend_settlement_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // Miscellaneous information about the payment settlement.
+  map<string, string> miscellaneous = 2;
 }
 
 // The response to be returned by the bank adapter once the settlement request
 // is executed.
 message SettlePaymentResponse {
-  // An identifier used by the bank's systems for the settlement operation. In
-  // India's UPI system, this translates to the `approval number`. This value is
-  // alpha-numeric and should be exactly 6 characters long.
-  string backend_settlement_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // Generic additional information.
-  repeated AdditionalInfo miscellaneous = 2;
+  // Payload for settle payment response.
+  message Payload {
+    // Information about a successful payment settlement.
+    SettlePaymentInfo settle_payment_info = 1;
+    // Any additional metadata about the response from the bank adapter.
+    ResponseMetadata response_metadata = 2;
+  }
+
+  // The response sent can be either a plain text response or encrypted in a
+  // Base64 encoded JSON string
+  oneof response {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.SettlePaymentResponse.Payload]
+    // message.
+    string encrypted = 2;
+  }
 }
 
 // Result of a settlement payment. Can be one of either a success or an error
@@ -89,7 +148,7 @@ message SettlePaymentResult {
   // Settlement payment can be either success or error.
   oneof settle_payment_result {
     // Successful settlement response.
-    SettlePaymentResponse success = 1;
+    SettlePaymentInfo success = 1;
     // Settlement Error Response.
     SettlePaymentError error = 2;
   }
@@ -105,47 +164,81 @@ message SettlePaymentError {
 
 // Request to search for a payment settlement.
 message SearchPaymentsRequest {
-  // Uniquely identifies the payment settlement transaction being searched for.
-  // This maps to the `Txn.Id` value in India's UPI system.
-  string payment_id = 1 [(google.api.field_behavior) = REQUIRED];
-  // Type of settlement.
-  SettlementType settlement_type = 2 [(google.api.field_behavior) = REQUIRED];
-  // Retrieval Reference Number (RRN) of the payment settlement being searched
-  // for.
-  string retrieval_reference_number = 3
-      [(google.api.field_behavior) = REQUIRED];
-  // Timestamp of the payment settlement transaction request being searched for.
-  google.protobuf.Timestamp request_time = 4
-      [(google.api.field_behavior) = REQUIRED];
-  // Metadata about the API invocation received by the issuer switch which
-  // triggered this request to the bank adapter.
-  InvocationMetadata invocation_metadata = 5
-      [(google.api.field_behavior) = REQUIRED];
+  // Payload for search payment request.
+  message Payload {
+    // Uniquely identifies the payment settlement transaction being searched
+    // for. This maps to the `Txn.Id` value in India's UPI system.
+    string payment_id = 1 [(google.api.field_behavior) = REQUIRED];
+    // Type of settlement.
+    SettlementType settlement_type = 2 [(google.api.field_behavior) = REQUIRED];
+    // Retrieval Reference Number (RRN) of the payment settlement being searched
+    // for.
+    string retrieval_reference_number = 3
+        [(google.api.field_behavior) = REQUIRED];
+    // Timestamp of the payment settlement transaction request being searched
+    // for.
+    google.protobuf.Timestamp request_time = 4
+        [(google.api.field_behavior) = REQUIRED];
+    // Metadata about the API invocation received by the issuer switch which
+    // triggered this request to the bank adapter.
+    InvocationMetadata invocation_metadata = 5
+        [(google.api.field_behavior) = REQUIRED];
+  }
+
+  // The request sent can be either a plain text request or encrypted in a
+  // Base64 encoded JSON string
+  oneof request {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.SearchPaymentsRequest.Payload]
+    // message.
+    string encrypted = 2;
+  }
 }
 
 // Information about a payment previously requested.
 message SearchPaymentsResponse {
-  // Payment settlement result. Can indicate either a success or an error during
-  // the processing of the original payment settlement.
-  SettlePaymentResult settlement_payment_response = 1
-      [(google.api.field_behavior) = REQUIRED];
-  // The status of the overall settlement.
-  SettlementState settlement_state = 2 [(google.api.field_behavior) = REQUIRED];
-  // The status of the overall settlement. It may have changed after it was
-  // executed (for example, if a refund was processed).
-  enum SettlementState {
-    // Unspecified settlement state.
-    STATE_UNSPECIFIED = 0;
-    // Successful settlement.
-    SUCCEEDED = 1;
-    // Failed settlement.
-    FAILED = 2;
-    // Partially completed settlement.
-    PARTIAL = 3;
-    // Deemed settlement.
-    DEEMED = 4;
-    // Revoked settlement.
-    REVOKED = 5;
+  // Payload for search payments response.
+  message Payload {
+    // Payment settlement result. Can indicate either a success or an error
+    // during the processing of the original payment settlement.
+    SettlePaymentResult settle_payment_result = 1
+        [(google.api.field_behavior) = REQUIRED];
+    // The status of the overall settlement. It may have changed after it was
+    // executed (for example, if a refund was processed).
+    enum SettlementState {
+      // Unspecified settlement state.
+      STATE_UNSPECIFIED = 0;
+      // Successful settlement.
+      SUCCEEDED = 1;
+      // Failed settlement.
+      FAILED = 2;
+      // Partially completed settlement.
+      PARTIAL = 3;
+      // Deemed settlement.
+      DEEMED = 4;
+      // Revoked settlement.
+      REVOKED = 5;
+    }
+    // The status of the overall settlement.
+    SettlementState settlement_state = 2
+        [(google.api.field_behavior) = REQUIRED];
+    // Any additional metadata about the response from the bank adapter.
+    ResponseMetadata response_metadata = 3;
+  }
+
+  // The response sent can be either a plain text response or encrypted in a
+  // Base64 encoded JSON string
+  oneof response {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.SearchPaymentsResponse.Payload]
+    // message.
+    string encrypted = 2;
   }
 }
 

--- a/upi-india/issuer-switch/bank-adapter/spec/v1/resolution_types.proto
+++ b/upi-india/issuer-switch/bank-adapter/spec/v1/resolution_types.proto
@@ -1,10 +1,10 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//      https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-package google.cloud.paymentgateway.issuerswitch.bankadapter.v1;
+package google.cloud.paymentgateway.issuerswitch.adapter.bank.v1;
 
 import "cloud/api_products/payment_gateway/upi_india/bank_adapter/spec/issuer/v1/common_types.proto";
 import "cloud/api_products/payment_gateway/upi_india/bank_adapter/spec/issuer/v1/payment_settlement_types.proto";
@@ -22,75 +22,107 @@ import "google/api/field_behavior.proto";
 
 option java_outer_classname = "ResolutionTypesProto";
 option java_multiple_files = true;
-option java_package = "com.google.cloud.paymentgateway.issuerswitch.bankadapter.v1";
+option java_package = "com.google.cloud.paymentgateway.issuerswitch.adapter.bank.v1";
 option go_api_flag = "OPAQUE_V0";
 
 // Individual payment resolution request.
 message ResolvePaymentRequest {
-  // Type of resolution to execute.
-  ResolutionType resolution_type = 1 [(google.api.field_behavior) = REQUIRED];
-  // Details of the original payment debit / credit settlement which needs to be
-  // resolved.
-  SettlePaymentRequest original_settle_payment_info = 2
-      [(google.api.field_behavior) = REQUIRED];
-  // Type of resolution workflow which triggered this request.
-  ResolutionWorkflow resolution_workflow = 3
-      [(google.api.field_behavior) = REQUIRED];
-  // If this request's _resolution workflow_ is `COMPLAINT`, then details of the
-  // complaint raised by the user/bank will be provided in this field.
-  CaseDetails case_details = 4 [(google.api.field_behavior) = REQUIRED];
-  // Metadata about the API invocation received by the issuer switch which
-  // triggered this request to the bank adapter.
-  InvocationMetadata invocation_metadata = 5
-      [(google.api.field_behavior) = REQUIRED];
-  // Type of resolution required to be done by bank in order resolve to an
-  // unresolved payment settlement.
-  enum ResolutionType {
-    // Unspecified resolution type.
-    RESOLUTION_TYPE_UNSPECIFIED = 0;
-    // Resolve an unresolved debit reversal transaction. The bank adapter
-    // service needs to check whether debit reversal was done for the debit
-    // specified in _original settle payment info_. If it was unsuccessful,
-    // then bank adapter or banks systems should resolve it by performing the
-    // debit reversal.
-    RESOLVE_DEBIT_REVERSAL = 1;
-    // Resolve an unresolved credit transaction. The bank adapter service needs
-    // to check whether the credit specified in _original settle payment info_
-    // was successful. If it was unsuccessful, then bank adapter or bank's
-    // systems should resolve the settlement by performing the credit.
-    RESOLVE_CREDIT = 2;
+  // Payload for resolve payment request.
+  message Payload {
+    // Type of resolution to execute.
+    ResolutionType resolution_type = 1 [(google.api.field_behavior) = REQUIRED];
+    // Details of the original payment debit / credit settlement which needs to
+    // be resolved.
+    SettlePaymentRequest original_settle_payment_info = 2
+        [(google.api.field_behavior) = REQUIRED];
+    // Type of resolution workflow which triggered this request.
+    ResolutionWorkflow resolution_workflow = 3
+        [(google.api.field_behavior) = REQUIRED];
+    // If this request's _resolution workflow_ is `COMPLAINT`, then details of
+    // the complaint raised by the user/bank will be provided in this field.
+    CaseDetails case_details = 4 [(google.api.field_behavior) = REQUIRED];
+    // Metadata about the API invocation received by the issuer switch which
+    // triggered this request to the bank adapter.
+    InvocationMetadata invocation_metadata = 5
+        [(google.api.field_behavior) = REQUIRED];
+    // Type of resolution required to be done by bank in order resolve to an
+    // unresolved payment settlement.
+    enum ResolutionType {
+      // Unspecified resolution type.
+      RESOLUTION_TYPE_UNSPECIFIED = 0;
+      // Resolve an unresolved debit reversal transaction. The bank adapter
+      // service needs to check whether debit reversal was done for the debit
+      // specified in _original settle payment info_. If it was unsuccessful,
+      // then bank adapter or banks systems should resolve it by performing the
+      // debit reversal.
+      RESOLVE_DEBIT_REVERSAL = 1;
+      // Resolve an unresolved credit transaction. The bank adapter service
+      // needs to check whether the credit specified in _original settle payment
+      // info_ was successful. If it was unsuccessful, then bank adapter or
+      // bank's systems should resolve the settlement by performing the credit.
+      RESOLVE_CREDIT = 2;
+    }
+
+    // Type of payment resolution workflow. This indicates the UPI workflow
+    // which triggered this request.
+    enum ResolutionWorkflow {
+      // Unspecified resolution workflow.
+      RESOLUTION_WORKFLOW_UNSPECIFIED = 0;
+      // UPI's auto-update workflow.
+      AUTOUPDATE_WORKFLOW = 1;
+      // UPI's complaint workflow.
+      COMPLAINT_WORKFLOW = 2;
+    }
   }
 
-  // Type of payment resolution workflow. This indicates the UPI workflow
-  // which triggered this request.
-  enum ResolutionWorkflow {
-    // Unspecified resolution workflow.
-    RESOLUTION_WORKFLOW_UNSPECIFIED = 0;
-    // UPI's auto-update workflow.
-    AUTOUPDATE_WORKFLOW = 1;
-    // UPI's complaint workflow.
-    COMPLAINT_WORKFLOW = 2;
+  // The request sent can be either a plain text request or encrypted in a
+  // Base64 encoded JSON string
+  oneof request {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.ResolvePaymentRequest.Payload]
+    // message.
+    string encrypted = 2;
   }
 }
 
 // The response to be returned by the bank adapter once the resolve payment
 // request is executed.
 message ResolvePaymentResponse {
-  // Resolve Payment result. Can indicate either a success or an error during
-  // resolution of an unresolved payment settlement.
-  ResolvePaymentResult resolve_payment_response = 1
-      [(google.api.field_behavior) = REQUIRED];
-  // The status of the resolution.
-  ResolutionStatus resolution_status = 2
-      [(google.api.field_behavior) = REQUIRED];
-  // Describes the status of payment resolution.
-  enum ResolutionStatus {
-    // Unspecified resolution state.
-    STATE_UNSPECIFIED = 0;
-    // Successful resolution.
-    SUCCEEDED = 1;
-    // Failed resolution.
-    FAILED = 2;
+  // Payload for resolve payment response.
+  message Payload {
+    // Resolve Payment result. Can indicate either a success or an error during
+    // resolution of an unresolved payment settlement.
+    ResolvePaymentResult resolve_payment_response = 1
+        [(google.api.field_behavior) = REQUIRED];
+    // Describes the status of payment resolution.
+    enum ResolutionStatus {
+      // Unspecified resolution state.
+      STATE_UNSPECIFIED = 0;
+      // Successful resolution.
+      SUCCEEDED = 1;
+      // Failed resolution.
+      FAILED = 2;
+    }
+    // The status of the resolution.
+    ResolutionStatus resolution_status = 2
+        [(google.api.field_behavior) = REQUIRED];
+    // Any additional metadata about the response from the bank adapter.
+    ResponseMetadata response_metadata = 3;
+  }
+
+  // The response sent can be either a plain text response or encrypted in a
+  // Base64 encoded JSON string
+  oneof response {
+    // The plain text payload.
+    Payload plain = 1;
+    // The encrypted payload encoded as a Base64 string. After decoding and
+    // decrypting, this value will be the same as the
+    // [Payload][google.cloud.paymentgateway.issuerswitch.adapter.bank.v1.ResolvePaymentResponse.Payload]
+    // message.
+    string encrypted = 2;
   }
 }
 


### PR DESCRIPTION
This commit includes the following changes:

- Includes support for *encryption* of request and response payloads.
- Includes an `InvocationMetadata` in all requests and a `ResponseMetadata` in all responses.
- Adds a `SettlePaymentInfo` message that is shared between `SettlePaymentResponse` and `SearchPaymentsResponse`.
- Models device details in a participant as a message.
- Replaces `ifsc_code` with just `ifsc`.
